### PR TITLE
Fix paste mixer recipes output item

### DIFF
--- a/kubejs/server_scripts/paste.js
+++ b/kubejs/server_scripts/paste.js
@@ -162,7 +162,7 @@ ServerEvents.recipes(event => {
         ],
         results: [
             {
-                item: 'create:paste',
+                item: 'kubejs:paste',
                 count: 3
             }
         ]
@@ -182,7 +182,7 @@ ServerEvents.recipes(event => {
         ],
         results: [
             {
-                item: 'create:paste',
+                item: 'kubejs:paste',
                 count: 2
             }
         ]


### PR DESCRIPTION
Create mixer recipes were outputting create:paste, which does not exist in the
  pack.

  Change them to kubejs:paste so flour/dough + water recipes produce the custom paste item.

  Tested in-game.